### PR TITLE
Add shebang to sky_shell

### DIFF
--- a/bin/sky_shell
+++ b/bin/sky_shell
@@ -1,3 +1,4 @@
+#!/bin/sh
 irb -rrubygems -rskyrack -rskyrack/instr
 
 # ree-1.8.7-2011.03 :002 > Instr.as("nop")


### PR DESCRIPTION
This fixes the following warning:

   WARNING:  bin/sky_shell is missing #! line
